### PR TITLE
add special role to capistrano recipies to dump from

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,8 @@ To get capistrano tasks in rails 3, put in `config/deploy.rb`:
 
     require 'dump/capistrano'
 
+    role :dump, 'example.com' # server with assets and db access to manage dumps
+
 ### Assets config
 
 `config/assets` holds paths of dirs you want to dump in file:

--- a/recipes/dump.rb
+++ b/recipes/dump.rb
@@ -170,12 +170,12 @@ Capistrano::Configuration.instance(:i_need_this!).load do
 
     namespace :local do
       desc "Shorthand for dump:local:create" << DumpRake::Env.explain_variables_for_command(:create)
-      task :default, :roles => :db, :only => {:primary => true} do
+      task :default, :roles => :dump do
         create
       end
 
       desc "Create local dump" << DumpRake::Env.explain_variables_for_command(:create)
-      task :create, :roles => :db, :only => {:primary => true} do
+      task :create, :roles => :dump do
         print_and_return_or_fail do
           with_additional_tags('local') do
             run_local(dump_command(:create))
@@ -184,22 +184,22 @@ Capistrano::Configuration.instance(:i_need_this!).load do
       end
 
       desc "Restore local dump" << DumpRake::Env.explain_variables_for_command(:restore)
-      task :restore, :roles => :db, :only => {:primary => true} do
+      task :restore, :roles => :dump do
         run_local(dump_command(:restore))
       end
 
       desc "Versions of local dumps" << DumpRake::Env.explain_variables_for_command(:versions)
-      task :versions, :roles => :db, :only => {:primary => true} do
+      task :versions, :roles => :dump do
         print run_local(dump_command(:versions, :show_size => true))
       end
 
       desc "Cleanup local dumps" << DumpRake::Env.explain_variables_for_command(:cleanup)
-      task :cleanup, :roles => :db, :only => {:primary => true} do
+      task :cleanup, :roles => :dump do
         print run_local(dump_command(:cleanup))
       end
 
       desc "Upload dump" << DumpRake::Env.explain_variables_for_command(:transfer)
-      task :upload, :roles => :db, :only => {:primary => true} do
+      task :upload, :roles => :dump do
         file = DumpRake::Env.with_env(:summary => nil) do
           last_part_of_last_line(run_local(dump_command(:versions)))
         end
@@ -211,12 +211,12 @@ Capistrano::Configuration.instance(:i_need_this!).load do
 
     namespace :remote do
       desc "Shorthand for dump:remote:create" << DumpRake::Env.explain_variables_for_command(:create)
-      task :default, :roles => :db, :only => {:primary => true} do
+      task :default, :roles => :dump do
         remote.create
       end
 
       desc "Create remote dump" << DumpRake::Env.explain_variables_for_command(:create)
-      task :create, :roles => :db, :only => {:primary => true} do
+      task :create, :roles => :dump do
         print_and_return_or_fail do
           with_additional_tags('remote') do
             run_remote("cd #{current_path}; #{dump_command(:create, :rake => fetch_rake, :RAILS_ENV => fetch_rails_env, :PROGRESS_TTY => '+')}")
@@ -225,22 +225,22 @@ Capistrano::Configuration.instance(:i_need_this!).load do
       end
 
       desc "Restore remote dump" << DumpRake::Env.explain_variables_for_command(:restore)
-      task :restore, :roles => :db, :only => {:primary => true} do
+      task :restore, :roles => :dump do
         run_remote("cd #{current_path}; #{dump_command(:restore, :rake => fetch_rake, :RAILS_ENV => fetch_rails_env, :PROGRESS_TTY => '+')}")
       end
 
       desc "Versions of remote dumps" << DumpRake::Env.explain_variables_for_command(:versions)
-      task :versions, :roles => :db, :only => {:primary => true} do
+      task :versions, :roles => :dump do
         print run_remote("cd #{current_path}; #{dump_command(:versions, :rake => fetch_rake, :RAILS_ENV => fetch_rails_env, :PROGRESS_TTY => '+', :show_size => true)}")
       end
 
       desc "Cleanup of remote dumps" << DumpRake::Env.explain_variables_for_command(:cleanup)
-      task :cleanup, :roles => :db, :only => {:primary => true} do
+      task :cleanup, :roles => :dump do
         print run_remote("cd #{current_path}; #{dump_command(:cleanup, :rake => fetch_rake, :RAILS_ENV => fetch_rails_env, :PROGRESS_TTY => '+')}")
       end
 
       desc "Download dump" << DumpRake::Env.explain_variables_for_command(:transfer)
-      task :download, :roles => :db, :only => {:primary => true} do
+      task :download, :roles => :dump do
         file = DumpRake::Env.with_env(:summary => nil) do
           last_part_of_last_line(run_remote("cd #{current_path}; #{dump_command(:versions, :rake => fetch_rake, :RAILS_ENV => fetch_rails_env, :PROGRESS_TTY => '+')}"))
         end
@@ -252,18 +252,18 @@ Capistrano::Configuration.instance(:i_need_this!).load do
     end
 
     desc "Shorthand for dump:local:upload" << DumpRake::Env.explain_variables_for_command(:transfer)
-    task :upload, :roles => :db, :only => {:primary => true} do
+    task :upload, :roles => :dump do
       local.upload
     end
 
     desc "Shorthand for dump:remote:download" << DumpRake::Env.explain_variables_for_command(:transfer)
-    task :download, :roles => :db, :only => {:primary => true} do
+    task :download, :roles => :dump do
       remote:download
     end
 
     namespace :mirror do
       desc "Creates local dump, uploads and restores on remote" << DumpRake::Env.explain_variables_for_command(:mirror)
-      task :up, :roles => :db, :only => {:primary => true} do
+      task :up, :roles => :dump do
         auto_backup = if auto_backup?
           with_additional_tags('auto-backup') do
             remote.create
@@ -283,7 +283,7 @@ Capistrano::Configuration.instance(:i_need_this!).load do
       end
 
       desc "Creates remote dump, downloads and restores on local" << DumpRake::Env.explain_variables_for_command(:mirror)
-      task :down, :roles => :db, :only => {:primary => true} do
+      task :down, :roles => :dump do
         auto_backup = if auto_backup?
           with_additional_tags('auto-backup') do
             local.create
@@ -305,12 +305,12 @@ Capistrano::Configuration.instance(:i_need_this!).load do
 
     namespace :backup do
       desc "Shorthand for dump:backup:create" << DumpRake::Env.explain_variables_for_command(:backup)
-      task :default, :roles => :db, :only => {:primary => true} do
+      task :default, :roles => :dump do
         create
       end
 
       desc "Creates remote dump and downloads to local (desc defaults to 'backup')" << DumpRake::Env.explain_variables_for_command(:backup)
-      task :create, :roles => :db, :only => {:primary => true} do
+      task :create, :roles => :dump do
         file = with_additional_tags('backup') do
           remote.create
         end
@@ -322,7 +322,7 @@ Capistrano::Configuration.instance(:i_need_this!).load do
       end
 
       desc "Uploads dump with backup tag and restores it on remote" << DumpRake::Env.explain_variables_for_command(:backup_restore)
-      task :restore, :roles => :db, :only => {:primary => true} do
+      task :restore, :roles => :dump do
         file = with_additional_tags('backup') do
           last_part_of_last_line(run_local(dump_command(:versions)))
         end


### PR DESCRIPTION
In my recent project I have separate app server and db server, so assets and db access granted only from app. But for now I cannot use gem dump for my project, because it use only db as role to dump.

I think that adding special role for this purpose will be fine.
