### PR TITLE
Empty restores handle

### DIFF
--- a/lib/dump_rake/dump_reader.rb
+++ b/lib/dump_rake/dump_reader.rb
@@ -219,17 +219,19 @@ class DumpRake
         end
 
         if DumpRake::Env[:restore_assets]
-          assets_paths.each do |asset|
-            DumpRake::Assets.glob_asset_children(asset, '**/*').reverse.each do |child|
-              if read_asset?(child, DumpRake::RailsRoot)
-                case
-                when File.file?(child)
-                  File.unlink(child)
-                when File.directory?(child)
-                  begin
-                    Dir.unlink(child)
-                  rescue Errno::ENOTEMPTY
-                    nil
+          unless DumpRake::Env[:restore_assets].empty?
+            assets_paths.each do |asset|
+              DumpRake::Assets.glob_asset_children(asset, '**/*').reverse.each do |child|
+                if read_asset?(child, DumpRake::RailsRoot)
+                  case
+                  when File.file?(child)
+                    File.unlink(child)
+                  when File.directory?(child)
+                    begin
+                      Dir.unlink(child)
+                    rescue Errno::ENOTEMPTY
+                      nil
+                    end
                   end
                 end
               end
@@ -241,9 +243,11 @@ class DumpRake
           end
         end
 
-        read_assets_entries(assets_paths, assets_count) do |stream, root, entry, prefix|
-          if !DumpRake::Env[:restore_assets] || read_asset?(entry.full_name, prefix)
-            stream.extract_entry(root, entry)
+        if !DumpRake::Env[:restore_assets] || !DumpRake::Env[:restore_assets].empty?
+          read_assets_entries(assets_paths, assets_count) do |stream, root, entry, prefix|
+            if !DumpRake::Env[:restore_assets] || read_asset?(entry.full_name, prefix)
+              stream.extract_entry(root, entry)
+            end
           end
         end
       end

--- a/spec/lib/dump_rake/dump_reader_spec.rb
+++ b/spec/lib/dump_rake/dump_reader_spec.rb
@@ -538,28 +538,51 @@ describe DumpReader do
         end
 
         describe "when called with restore_assets" do
-          it "should delete files and dirs only in requested paths" do
-            @assets = %w[images videos]
-            @dump.stub(:config).and_return({:assets => @assets})
+          describe "non empty" do
+            it "should delete files and dirs only in requested paths" do
+              @assets = %w[images videos]
+              @dump.stub(:config).and_return({:assets => @assets})
 
-            DumpRake::Assets.should_receive('glob_asset_children').with('images', '**/*').and_return(%w[images images/a.jpg images/b.jpg])
-            DumpRake::Assets.should_receive('glob_asset_children').with('videos', '**/*').and_return(%w[videos videos/a.mov])
+              DumpRake::Assets.should_receive('glob_asset_children').with('images', '**/*').and_return(%w[images images/a.jpg images/b.jpg])
+              DumpRake::Assets.should_receive('glob_asset_children').with('videos', '**/*').and_return(%w[videos videos/a.mov])
 
-            @dump.should_receive('read_asset?').with('images/b.jpg', DumpRake::RailsRoot).ordered.and_return(false)
-            @dump.should_receive('read_asset?').with('images/a.jpg', DumpRake::RailsRoot).ordered.and_return(true)
-            @dump.should_receive('read_asset?').with('images', DumpRake::RailsRoot).ordered.and_return(true)
-            @dump.should_receive('read_asset?').with('videos/a.mov', DumpRake::RailsRoot).ordered.and_return(false)
-            @dump.should_receive('read_asset?').with('videos', DumpRake::RailsRoot).ordered.and_return(false)
+              @dump.should_receive('read_asset?').with('images/b.jpg', DumpRake::RailsRoot).ordered.and_return(false)
+              @dump.should_receive('read_asset?').with('images/a.jpg', DumpRake::RailsRoot).ordered.and_return(true)
+              @dump.should_receive('read_asset?').with('images', DumpRake::RailsRoot).ordered.and_return(true)
+              @dump.should_receive('read_asset?').with('videos/a.mov', DumpRake::RailsRoot).ordered.and_return(false)
+              @dump.should_receive('read_asset?').with('videos', DumpRake::RailsRoot).ordered.and_return(false)
 
-            File.should_receive('file?').with('images/a.jpg').and_return(true)
-            File.should_receive('unlink').with('images/a.jpg')
-            File.should_not_receive('file?').with('images/b.jpg')
-            File.should_receive('file?').with('images').and_return(false)
-            File.should_receive('directory?').with('images').and_return(true)
-            Dir.should_receive('unlink').with('images').and_raise(Errno::ENOTEMPTY)
+              File.should_receive('file?').with('images/a.jpg').and_return(true)
+              File.should_receive('unlink').with('images/a.jpg')
+              File.should_not_receive('file?').with('images/b.jpg')
+              File.should_receive('file?').with('images').and_return(false)
+              File.should_receive('directory?').with('images').and_return(true)
+              Dir.should_receive('unlink').with('images').and_raise(Errno::ENOTEMPTY)
 
-            DumpRake::Env.with_env(:restore_assets => 'images/a.*:stylesheets') do
-              @dump.read_assets
+              DumpRake::Env.with_env(:restore_assets => 'images/a.*:stylesheets') do
+                @dump.read_assets
+              end
+            end
+          end
+
+          describe "empty" do
+            it "should not delete any files and dirs" do
+              @assets = %w[images videos]
+              @dump.stub(:config).and_return({:assets => @assets})
+
+              DumpRake::Assets.should_not_receive('glob_asset_children')
+              DumpRake::Assets.should_not_receive('glob_asset_children')
+
+              @dump.should_not_receive('read_asset?')
+
+              File.should_not_receive('file?')
+              File.should_not_receive('unlink')
+              File.should_not_receive('file?')
+              File.should_not_receive('directory?')
+
+              DumpRake::Env.with_env(:restore_assets => '') do
+                @dump.read_assets
+              end
             end
           end
         end


### PR DESCRIPTION
Added handling for two specific cases: RESTORE_TABLES='' or RESTORE_ASSETS=''. Previously in this cases gem was iterating through assets and tables. Now it ignores empty part.
