### PR TITLE
Table name confusion

### DIFF
--- a/lib/dump/reader.rb
+++ b/lib/dump/reader.rb
@@ -97,7 +97,7 @@ module Dump
 
     def find_entry(matcher)
       stream.each do |entry|
-        if entry.full_name.match(matcher)
+        if entry.full_name == matcher
           # we can not return entry - after exiting stream.each the entry will be invalid and will read from tar start
           return yield(entry)
         end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -4,4 +4,10 @@ ActiveRecord::Schema.define(:version => 0) do
       t.column "#{type}_col", type
     end
   end
+
+  create_table :another_chickens, :force => true do |t|
+    %w[string text decimal datetime timestamp date ].each do |type|
+      t.column "#{type}_col", type
+    end
+  end
 end

--- a/spec/dump/reader_spec.rb
+++ b/spec/dump/reader_spec.rb
@@ -143,29 +143,30 @@ describe Reader do
 
   describe 'low level' do
     before do
+      @e0 = double('e0', :full_name => 'another_first.dump', :read => 'another_first.dump_data')
       @e1 = double('e1', :full_name => 'config', :read => 'config_data')
       @e2 = double('e2', :full_name => 'first.dump', :read => 'first.dump_data')
       @e3 = double('e3', :full_name => 'second.dump', :read => 'second.dump_data')
-      @stream = [@e1, @e2, @e3]
+      @stream = [@e0, @e1, @e2, @e3]
       @dump = described_class.new('123.tgz')
       allow(@dump).to receive(:stream).and_return(@stream)
     end
 
     describe 'find_entry' do
-      it 'finds first entry in stream equal string' do
+      it 'finds entry in stream equal string' do
         @dump.find_entry('config') do |entry|
           expect(entry).to eq(@e1)
         end
       end
 
-      it 'finds first entry in stream matching regexp' do
-        @dump.find_entry(/\.dump$/) do |entry|
+      it 'finds exact entry in stream without confusion' do
+        @dump.find_entry('first.dump') do |entry|
           expect(entry).to eq(@e2)
         end
       end
 
       it 'returns result of block' do
-        expect(@dump.find_entry(/\.dump$/) do |_entry|
+        expect(@dump.find_entry('first.dump') do |_entry|
           'hello'
         end).to eq('hello')
       end


### PR DESCRIPTION
Hi folks!

I mess with annoying problem of regexp search in `Dump::Reade#find_entry`. If one table name is a substring of another and it is lower in alphanumerical order, for example for `users` and `admin_users`, it tries to restore `admin_users.dump` into `users` table.

I changed some tests and fix this.