### PR TITLE
handles MS SQL server table chunk

### DIFF
--- a/lib/dump/table_manipulation.rb
+++ b/lib/dump/table_manipulation.rb
@@ -112,13 +112,8 @@ module Dump
       if table_has_primary_column?(table) && row_count > chunk_size
         # adapted from ActiveRecord::Batches
         primary_key = table_primary_key(table)
-        quoted_primary_key =
-          "#{quote_table_name(table)}.#{quote_column_name(primary_key)}"
         select_where_primary_key =
-          "SELECT * FROM #{quote_table_name(table)}" \
-            " WHERE #{quoted_primary_key} %s" \
-            " ORDER BY #{quoted_primary_key} ASC" \
-            " LIMIT #{chunk_size}"
+          sql_select_where_primary_key_by_adapter(table, primary_key, chunk_size)
         rows = select_all_by_sql(select_where_primary_key % '>= 0')
         until rows.blank?
           rows.each(&block)
@@ -143,6 +138,22 @@ module Dump
 
     def connection
       ActiveRecord::Base.connection
+    end
+
+    def sql_select_where_primary_key_by_adapter(table, primary_key, chunk_size)
+      quoted_primary_key =
+        "#{quote_table_name(table)}.#{quote_column_name(primary_key)}"
+      adapter = connection.adapter_name.downcase
+      if adapter == 'sqlserver'
+        "SELECT TOP #{chunk_size} * FROM #{quote_table_name(table)}" \
+          " WHERE #{quoted_primary_key} %s" \
+          " ORDER BY #{quoted_primary_key} ASC"
+      else
+        "SELECT * FROM #{quote_table_name(table)}" \
+          " WHERE #{quoted_primary_key} %s" \
+          " ORDER BY #{quoted_primary_key} ASC" \
+          " LIMIT #{chunk_size}"
+      end
     end
   end
 end


### PR DESCRIPTION
Hi,

When the size of table is larger than `CHUNK_SIZE_MAX = 3_000`, it enters each_table_row method in TableManipulation. However, the SQL syntax there is using "LIMIT" which is not supported in MS SQL server. So I added syntax for SQL server which is using TOP based on the `ActiveRecord::Base.connection_config[:adapter]`